### PR TITLE
Update lib/schema_to_scaffold/schema.rb

### DIFF
--- a/lib/schema_to_scaffold/schema.rb
+++ b/lib/schema_to_scaffold/schema.rb
@@ -25,7 +25,7 @@ module SchemaToScaffold
     end
 
     def self.parse(data)
-      data.split(/create_/)[1..-1].map {|table_data| Table.parse table_data }
+      data.split(/^\s*create_/)[1..-1].map {|table_data| Table.parse table_data }
     end
   end
 end


### PR DESCRIPTION
Added prefix selection to the "create_table" splitter so that it doesn't pick up fields with a name that matches "create_" (thus creating bad table_data and resulting in failure all around).
