### PR TITLE
changed Table.parse regex from .+ to ^" ...

### DIFF
--- a/lib/schema_to_scaffold/table.rb
+++ b/lib/schema_to_scaffold/table.rb
@@ -17,7 +17,7 @@ module SchemaToScaffold
     end
 
     def self.parse(table_data)
-      return unless name = table_data[/table "(.+)"/]
+      return unless name = table_data[/table "([^"]+)"/]
       name = $1
       atts = table_data.lines.to_a.select {|line| line =~ /t\.\w+/ }.map {|att| Attribute.parse att }
       Table.new(name, atts)


### PR DESCRIPTION
... else it sucks in more than it should whenever there are more quotes in the schema string than expected -- for example:

create_table "customer", primary_key: "cnum", force: true do |t|

still not really an air-tight regex, but a bit less permissive.
