### PR TITLE
Added --no-migration flag to scaffolding

### DIFF
--- a/lib/schema_to_scaffold/table.rb
+++ b/lib/schema_to_scaffold/table.rb
@@ -12,7 +12,7 @@ module SchemaToScaffold
     end
 
     def to_script(target)
-      return "rails generate #{target} #{modelize name} #{attributes.map(&:to_script).reject{|x| x.nil? || x.empty?}.join(' ')}" if target == "scaffold"
+      return "rails generate #{target} #{modelize name} #{attributes.map(&:to_script).reject{|x| x.nil? || x.empty?}.join(' ')} --no-migration" if target == "scaffold"
       return "rails generate #{target} #{modelize name} #{attributes.map(&:to_script).reject{|x| x.nil? || x.empty?}.join(' ')}" if target == "factory_girl:model"
     end
 


### PR DESCRIPTION
Since the whole point of schema_to_scaffold is to create Rails files around an existing database, a migration should almost invariably be wrong. This changes the default to no-migration, though of course users could still remove the flag manually.

Even after using schema_to_scaffold multiple times, I was still tripping over forgetting to remove the migration. Better not to generate it, since the database will already be in the correct state.
