### PR TITLE
Working clipboard and -f for factory_girl

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,21 @@
 
 [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/frenesim/schema_to_scaffold)
 
-This Gem shall generate rails commands strings based on a rails database schema you already have.<br>
-Generated string commands available are:<br>
-`rails generate scaffold <model_name> <field[:type]>`<br>
-`rails generate factory_girl:model <ModelName> <field[:type]>`
+This Gem generates Rails command strings based on a Rails database schema you already have. Unlike traditional migrations, which modify the database as they generate Rails scaffolding code, this Gem reads the database and generates the Rails code which matches your database's existing columns.
 
-Important:
-This gem will not run code for you. It will only generate a string for you to copy and paste
+This Gem does not modify anything; it simply prints a string which will then invoke the Rails generators, and optionally copies the string to your clipboard. Generated string commands available are:
+```bash
+rails generate scaffold <model_name> <field[:type]>
+rails generate factory_girl:model <ModelName> <field[:type]>
+```
 
-Use your schema.rb file from `<rails_app>/db` or generated with `rake db:schema:dump`
-You can rename schema.rb to schema_your_fav_name.rb that I will find it too. This will prevent schema.rb from being
-overwritten when one run rake db:migrate.
+Use your schema.rb file from `<rails_app>/db` or generated with `rake db:schema:dump`. You can optionally rename schema.rb to `schema_your_fav_name.rb` and it will still be found. Unique schema file names will prevent schema.rb from being overwritten when you run `rake db:migrate`.
 
-SchemaToScaffold will generate rails scaffolding scripts by table like this:
+Schema to Scaffold will generate rails scaffolding scripts by table like this:
 
-    rails g scaffold users fname:string lname:string bdate:date email:string encrypted_password:string
+    rails generate scaffold users fname:string lname:string bdate:date email:string encrypted_password:string
 
-It's possible to generate scripts for all your tables at once. Just choose '*' when choosing the table.
+It's possible to generate scripts for all your tables at once. Just choose `*` when choosing the table.
 
 ## Installation
 
@@ -26,25 +24,50 @@ Assuming that you have rubygems-bundler installed, just type:
 
     gem install schema_to_scaffold
 
-
 ## Usage
 
-Just type:
+```
+Usage: scaffold [options] 
+Generate a rails scaffold script for a given schema.rb
+ -h             Displays help.
+ -p <path>      It specifies a path to a folder or to a file.
+ -c             Will copy the script to your clipboard. Requires xclip be installed on Linux.
+ -f             Generates a factory_girl:model rather than a full scaffold.
 
-    scaffold [options]
-    
-	[options]
-        -h			Displays help.
-	-p <path>		It specifies a search path or a path to a file 
-					ex: -p /user/path  or  /path/to/your/schema.rb
-	-c				Works only on linux. Will copy the script copied to your clipboard.
-					You will need to have xclip installed(see below).
+Examples:
+scaffold
+scaffold -c -p ~/work/rails/my_app
+scaffold -c -p ~/work/rails/my_app/db/schema.rb
+```
+## Generators
 
-### To install xclip
+Since this gem will let you invoke Rails generators for your scaffolding, make sure you've configured your generators with your preferred settings before start. There's a good [Rails Guide](http://guides.rubyonrails.org/generators.html) and you can invoke `rails g scaffold -h` to see options.
+
+Generator options are configured in `config/application.rb`. Here is an example setting:
+
+```ruby
+module YourApplication
+  class Application < Rails::Application
+    config.generators do |g|
+      g.hidden_namespaces << :test_unit << :erb # Hide unwanted generators
+      g.template_engine :slim # Select template engine
+      g.test_framework  :rspec, :view_specs => false
+      g.integration_tool :rspec
+      g.fixture_replacement :factory_girl # Choose between fixtures and factories
+      g.factory_girl dir: 'spec/factories'
+      g.javascript_engine :js # Disable coffeescript
+      g.scaffold_controller "responders_controller" # from responders gem
+    end
+  end
+end
+```
+If you configure factory_girl as your fixture_replacement here, there is no need to invoke factory_girl separately with the `scaffold -f` command.
+
+## To install xclip on Linux
 
     sudo apt-get install xclip
-    
-### Contributing
+
+## Contributing
 
 	Want to contribute? Great!
 
@@ -57,6 +80,6 @@ Just type:
 
 [1]: http://github.com/frenesim/schema_to_scaffold/pulls
 
-### Collaborate
+## Collaborate
 
 	If you want to collaborate send me an email please. 

--- a/bin/scaffold
+++ b/bin/scaffold
@@ -51,21 +51,24 @@ else
   tables = [result.to_i]
 end
 
-script_scaffold = []
-script_factory_girl = []
-tables.each do |table_id|
-  script_scaffold << SchemaToScaffold.generate_script(schema, table_id,"scaffold")
-  script_factory_girl << SchemaToScaffold.generate_script(schema, table_id,"factory_girl:model")
+script = []
+
+if opts[:factory_girl]
+  tables.each { |table_id| script << SchemaToScaffold.generate_script(schema, table_id, "factory_girl:model") }
+  puts "\nScript for factory girl:\n\n"
+  puts script.join("")
+else
+  tables.each { |table_id| script << SchemaToScaffold.generate_script(schema, table_id, "scaffold") }
+  puts "\nScript for rails scaffold:\n\n"
+  puts script.join("")
 end
 
-puts "\nScript for rails scaffold"
-puts script_scaffold.join("\n")
-
-puts "\nScript for factory girl"
-puts script_factory_girl.join("\n")
-
-
-if opts[:xclip]
+if opts[:clipboard]
   puts("\n(copied to your clipboard)")
-  exec("echo '#{script}' | xclip -selection c")
+  case RUBY_PLATFORM
+    when /darwin/i then exec("echo '#{script.join("")}' | tr -d '\n' | pbcopy")
+    when /linux/i  then exec("echo '#{script.join("")}' | tr -d '\n' | xclip -selection c")
+    when /mingw/i  then exec("echo '#{script.join("")}' | clip")
+    when /win/i    then exec("echo '#{script.join("")}' | clip")
+  end
 end

--- a/lib/schema_to_scaffold.rb
+++ b/lib/schema_to_scaffold.rb
@@ -14,7 +14,9 @@ module SchemaToScaffold
 Usage: scaffold [options] 
 Generate a rails scaffold script for a given schema.rb
  -h             Displays help.
- -p <path>      It specifies a path to a folder or to a file
+ -p <path>      It specifies a path to a folder or to a file.
+ -c             Will copy the script to your clipboard. Requires xclip be installed on Linux.
+ -f             Generates a factory_girl:model rather than a full scaffold.
 
 END_OF_HELP
 
@@ -25,13 +27,12 @@ END_OF_HELP
 Examples:
 scaffold 
 scaffold -p C:\\Users\\JohnDoe
-scaffold -p C:\\Users\\JohnDoe\\Documents\\schema.rb
+scaffold -c -p C:\\Users\\JohnDoe\\Documents\\schema.rb
 WINDOWS_SAMPLE
 
   ## Linux specific usage help text
 
   LINUX_HELP = <<-LINUX_SAMPLE
-     -c             Works only on linux. Will copy the script copied to your clipboard. You will need to have xclip installed(see below).
 Examples:
 scaffold
 scaffold -c -p ~/work/rails/my_app
@@ -41,9 +42,10 @@ LINUX_SAMPLE
   def help_msg
     return GENERIC_HELP +
     case RUBY_PLATFORM
-    when /win/i   then WINDOWS_HELP
-    when /mingw/i then WINDOWS_HELP
-    when /linux/i then LINUX_HELP
+    when /darwin/i then LINUX_HELP
+    when /linux/i  then LINUX_HELP
+    when /mingw/i  then WINDOWS_HELP
+    when /win/i    then WINDOWS_HELP
     end
   end
 
@@ -56,7 +58,8 @@ LINUX_SAMPLE
       argv.delete('-p')
     end
     args = {
-      :xclip => argv.delete('-c'),        # check for xclip flag
+      :clipboard => argv.delete('-c'),        # check for clipboard flag
+      :factory_girl => argv.delete('-f'), # factory_girl instead of scaffold
       :help =>  argv.delete('-h'),        # check for help flag
       :path =>  path                      # get path to file(s)
     }


### PR DESCRIPTION
These are some substantial changes based on my experience with the gem. First, the clipboard now works for Mac and Windows as well as Linux. Note that the Linux option is currently broken upstream, as `scripts` is undefined.

Also, it no longer makes sense to have factory_girl as a top-level output, since most users will want to configure their generators to create factory_girl as part of the regular scaffolding. I explained this in the Readme, gave an example of configuring generators, and moved factory_girl behind a `-f`. This also makes the clipboard more useful, since it's just for a single command.

Thanks for creating the gem, which has been immensely helpful to me, and thanks for considering these changes.
