### PR TITLE
Remove reference to depcrecated `Fixnum` class

### DIFF
--- a/lib/schema_to_scaffold/schema.rb
+++ b/lib/schema_to_scaffold/schema.rb
@@ -28,7 +28,7 @@ module SchemaToScaffold
       case id
       when Symbol then table(id.to_s)
       when String then tables[table_names.index(id)]
-      when Fixnum then tables[id]
+      when Integer then tables[id]
       else nil
       end
     end

--- a/lib/schema_to_scaffold/version.rb
+++ b/lib/schema_to_scaffold/version.rb
@@ -1,6 +1,6 @@
 module SchemaToScaffold
   MAJOR = 0
   MINOR = 8
-  REVISION = 0
+  REVISION = 1
   VERSION = [MAJOR, MINOR, REVISION].join('.')
 end


### PR DESCRIPTION
`Fixnum` was [deprecated](https://bugs.ruby-lang.org/issues/12005) in Ruby 2.4 when `Fixnum` and `Bignum` were unified into their parent class, `Integer`. This patch removes the deprecation warning.

Non-breaking change, no requirement to change minimum Ruby version or bump this gem's version number significantly.

All specs pass unchanged (although I did need to create the `spec/support/no_schema` folder... this PR also adds a `.keep` file in that folder to make sure it gets preserved when fetching a fresh clone of the repo).